### PR TITLE
bug-erms-5176

### DIFF
--- a/documentation/CHANGELOG-TMP.md
+++ b/documentation/CHANGELOG-TMP.md
@@ -7,6 +7,8 @@
 
 **Ticket    Date    Branch  Version(current) Author  Feature/Bug     Description/Keywords**
 
+5176    05.07.2023  dev     3.2         Andreas Bug         Konsortialmanager Basic fehlten in GASCO-Auflistung
+
 5172    04.07.2023  dev     3.2         David   Bug         Anmerkungen: doppelter Titel
 
 5174    04.07.2023  dev     3.2         Andreas Bug         Menüeinträge für Konsortialmanager-Basic ausgegraut

--- a/grails-app/controllers/de/laser/PublicController.groovy
+++ b/grails-app/controllers/de/laser/PublicController.groovy
@@ -107,7 +107,7 @@ class PublicController {
                 """select o from Org o, OrgSetting os_gs, OrgSetting os_ct where 
                         os_gs.org = o and os_gs.key = 'GASCO_ENTRY' and os_gs.rdValue.value = 'Yes' and 
                         os_ct.org = o and os_ct.key = 'CUSTOMER_TYPE' and 
-                        os_ct.roleValue in (select r from Role r where authority  = 'ORG_CONSORTIUM_PRO')
+                        os_ct.roleValue in (select r from Role r where authority in ('ORG_CONSORTIUM_PRO','ORG_CONSORTIUM_BASIC'))
                         order by lower(o.name)"""
         )
 


### PR DESCRIPTION
as of ERMS-5176, the GASCO view now displays basic consortia