### PR TITLE
bug-erms-5638

### DIFF
--- a/documentation/CHANGELOG.md
+++ b/documentation/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 **Ticket    Date    Branch  Version(current) Author  Feature/Bug     Description/Keywords**
 
+5638    11.04.2024  dev     3.4         Andreas Bug         Beifang von leeren Adresszeilen entfernt
+
 5639    10.04.2024  dev     3.4         Andreas Bug         Argumentfehler in Abfrage behoben
 
 5636    10.04.2024  dev     3.4         Andreas Bug         if-Abfrage zum Abfangen ungültiger Sortierparameter korrigiert

--- a/grails-app/views/templates/_copyEmailaddresses.gsp
+++ b/grails-app/views/templates/_copyEmailaddresses.gsp
@@ -105,7 +105,9 @@
                     //$("#emailAddressesTextArea").val(data.join('; '));
                     $.each(data, function (i, e) {
                         $("#"+i+" span.address").text(e.join('; '));
+                        $("#"+i).show();
                     });
+                    $("span.address:empty").parents("tr").hide();
                 }
             });
         }


### PR DESCRIPTION
as of ERMS-5638, empty rows are being eliminated from address modal