### PR TITLE
Wiki dev

### DIFF
--- a/src/main/resources/help/subscription_show.md
+++ b/src/main/resources/help/subscription_show.md
@@ -1,0 +1,4 @@
+Das Lizenzinformationsblatt beinhaltet alle Metadaten und Informationen, sowie Verknüpfung zu Objekten, wie Paketen und Verträgen, welche der Lizenz angehören. 
+In der **Übersicht** sind diese kompakt dargestellt. 
+
+Mehr dazu erfahren Sie auf dieser Seite: Link zur Hilfeseite des Lizenzinformationsblatts

--- a/src/main/resources/help/subscription_show.md
+++ b/src/main/resources/help/subscription_show.md
@@ -1,4 +1,4 @@
 Das Lizenzinformationsblatt beinhaltet alle Metadaten und Informationen, sowie Verknüpfung zu Objekten, wie Paketen und Verträgen, welche der Lizenz angehören. 
 In der **Übersicht** sind diese kompakt dargestellt. 
 
-Mehr dazu erfahren Sie auf dieser Seite: Link zur Hilfeseite des Lizenzinformationsblatts
+Mehr dazu erfahren Sie auf dieser Seite: *(Link zur Hilfeseite des Lizenzinformationsblatts)*


### PR DESCRIPTION
Erstmal ein Test-Dok. 

@klodav, das Lizenzinformationsblatt hat bereits das Flyout "Erklärung der Icons". Passiert etwas durch die Doppelungen oder sind die zwei Flyouts unabhängig voneinander? Erscheinen dann zwei "Fragezeichen"-Icons am rechten, oberen Rand? 